### PR TITLE
feat: Add team planner and remove premium pricing card

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,6 +704,198 @@
                 display: none !important;
             }
         }
+
+        /* Styles for 25/26 Team Planner Section */
+        #team-planner-section .planner-content {
+            display: flex;
+            flex-wrap: wrap; /* Allow wrapping for smaller screens if necessary */
+            gap: 2rem; /* Space between player selection and squad summary */
+            background-color: white; /* White background for the content area */
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+        }
+
+        .player-selection-area {
+            flex: 3; /* Takes up more space, e.g., ~60-65% */
+            min-width: 300px; /* Minimum width before wrapping */
+        }
+
+        .squad-summary-area {
+            flex: 2; /* Takes up less space, e.g., ~35-40% */
+            min-width: 250px; /* Minimum width */
+            background-color: var(--light);
+            padding: 1.5rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+
+        .player-selection-area h3, .squad-summary-area h3 {
+            color: var(--primary);
+            margin-bottom: 1rem;
+        }
+        .squad-summary-area h4 {
+            color: var(--primary);
+            margin-top: 1.5rem;
+            margin-bottom: 0.5rem;
+            font-size: 1.1rem;
+        }
+
+
+        .filters-sort {
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .filters-sort label {
+            font-weight: 500;
+            color: var(--primary);
+        }
+
+        .filters-sort select {
+            padding: 0.5rem;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 0.9rem;
+        }
+
+        .player-list-table-container {
+            max-height: 500px; /* Max height before scrolling */
+            overflow-y: auto;  /* Enable vertical scrollbar if content exceeds max-height */
+            border: 1px solid #eee;
+            border-radius: 4px;
+        }
+
+        #player-list-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        #player-list-table th, #player-list-table td {
+            border-bottom: 1px solid #ddd; /* Light border for rows */
+            padding: 0.75rem; /* Increased padding */
+            text-align: left;
+            font-size: 0.9rem;
+        }
+
+        #player-list-table th {
+            background-color: var(--light);
+            color: var(--primary);
+            font-weight: 600; /* Bolder headers */
+            position: sticky; /* Make headers stick during scroll */
+            top: 0;
+            z-index: 10;
+        }
+        
+        #player-list-table tbody tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+
+        #player-list-table tbody tr:hover {
+            background-color: #f1f1f1; /* Hover effect for rows */
+        }
+
+        .player-add-button {
+            padding: 0.4rem 0.8rem;
+            background-color: var(--secondary);
+            color: var(--primary);
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.85rem;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .player-add-button:hover {
+            background-color: #00cc6a; /* Darker shade on hover */
+        }
+        
+        .player-add-button:disabled {
+            background-color: var(--gray);
+            color: white;
+            cursor: not-allowed;
+        }
+
+        .budget-info, .squad-composition-info {
+            font-size: 1.1rem;
+            margin-bottom: 0.75rem;
+            padding: 0.5rem;
+            background-color: white;
+            border-radius: 4px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        }
+        .budget-info span, .squad-composition-info span {
+            font-weight: bold;
+            color: var(--primary);
+        }
+
+        .squad-position-list {
+            list-style-type: none; /* Remove default bullet points */
+            padding-left: 0;
+            margin-bottom: 1.5rem; /* Space below each list */
+        }
+
+        .squad-position-list li {
+            background-color: white;
+            padding: 0.6rem 0.8rem;
+            margin-bottom: 0.5rem;
+            border-radius: 4px;
+            border: 1px solid #e0e0e0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.9rem;
+        }
+        
+        .squad-position-list li .player-name {
+            font-weight: 500;
+        }
+        .squad-position-list li .player-price {
+            color: var(--gray);
+            font-size: 0.85rem;
+        }
+
+        .remove-player-btn {
+            background-color: var(--danger);
+            color: white;
+            border: none;
+            padding: 0.3rem 0.6rem;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .remove-player-btn:hover {
+            background-color: #c82333; /* Darker red on hover */
+        }
+        
+        #reset-squad-button.btn-danger { /* Ensure it picks up danger color */
+            background-color: var(--danger);
+            color: white;
+        }
+        #reset-squad-button.btn-danger:hover {
+            background-color: #c82333;
+        }
+
+        /* Responsive adjustments for planner */
+        @media (max-width: 992px) { /* Adjust breakpoint as needed */
+            #team-planner-section .planner-content {
+                flex-direction: column; /* Stack columns on smaller screens */
+            }
+            .player-selection-area, .squad-summary-area {
+                flex: none; /* Reset flex basis */
+                width: 100%; /* Full width for stacked columns */
+            }
+            .player-list-table-container {
+                 max-height: 400px; /* Adjust height for smaller screens */
+            }
+        }
+
     </style>
 </head>
 <body>
@@ -718,6 +910,7 @@
                     <li><a href="#predictions">Predictions</a></li>
                     <li><a href="#live-tools">Live Tools</a></li>
                     <li><a href="#analysis">Analyse</a></li>
+                    <li><a href="#team-planner-section">25/26 Planner</a></li>
                     <li><a href="#pricing">Pricing</a></li>
                 </ul>
             </nav>
@@ -961,6 +1154,88 @@
             </div>
         </div>
     </section>
+
+    <section class="dashboard-demo" id="team-planner-section">
+        <div class="container">
+            <div class="section-title">
+                <h2>25/26 Planner</h2>
+                <p>Plan your dream squad for the next Fantasy Premier League season.</p>
+            </div>
+
+            <!-- Main content area for the planner -->
+            <div class="planner-content">
+
+                <!-- Left side: Player selection table and filters -->
+                <div class="player-selection-area">
+                    <h3>Available Players</h3>
+                    <div class="filters-sort">
+                        <!-- Position Filter -->
+                        <label for="position-filter">Position:</label>
+                        <select id="position-filter">
+                            <option value="all">All</option>
+                            <option value="GK">Goalkeepers (GK)</option>
+                            <option value="DEF">Defenders (DEF)</option>
+                            <option value="MID">Midfielders (MID)</option>
+                            <option value="FWD">Forwards (FWD)</option>
+                        </select>
+                        <!-- Sorting (to be implemented later if needed via JS) -->
+                    </div>
+                    <div class="player-list-table-container">
+                        <table id="player-list-table">
+                            <thead>
+                                <tr>
+                                    <th>Player</th>
+                                    <th>Team</th>
+                                    <th>Pos.</th>
+                                    <th>Price (£m)</th>
+                                    <th>Total Pts (LS)</th>
+                                    <th>Recent Pts*</th>
+                                    <th>Add</th>
+                                </tr>
+                            </thead>
+                            <tbody id="player-list-tbody">
+                                <!-- Player rows will be dynamically inserted here by JavaScript -->
+                            </tbody>
+                        </table>
+                        <p><small>*Recent Pts refers to form or last few gameweeks' average if available.</small></p>
+                    </div>
+                </div>
+
+                <!-- Right side: Squad display and budget information -->
+                <div class="squad-summary-area">
+                    <h3>Your Squad</h3>
+                    <div class="budget-info">
+                        <span>Budget: £</span><span id="budget-remaining">100.0</span>m
+                    </div>
+                    <div class="squad-composition-info">
+                        <span>Players: </span><span id="total-players-selected">0</span>/15
+                    </div>
+
+                    <!-- Squad display separated by positions -->
+                    <h4>Goalkeepers (<span id="gk-count">0</span>/2)</h4>
+                    <ul id="squad-goalkeepers" class="squad-position-list">
+                        <!-- Selected GKs will be listed here -->
+                    </ul>
+
+                    <h4>Defenders (<span id="def-count">0</span>/5)</h4>
+                    <ul id="squad-defenders" class="squad-position-list">
+                        <!-- Selected DEFs will be listed here -->
+                    </ul>
+
+                    <h4>Midfielders (<span id="mid-count">0</span>/5)</h4>
+                    <ul id="squad-midfielders" class="squad-position-list">
+                        <!-- Selected MIDs will be listed here -->
+                    </ul>
+
+                    <h4>Forwards (<span id="fwd-count">0</span>/3)</h4>
+                    <ul id="squad-forwards" class="squad-position-list">
+                        <!-- Selected FWDs will be listed here -->
+                    </ul>
+                    <button id="reset-squad-button" class="btn btn-danger" style="margin-top: 1rem;">Reset Squad</button>
+                </div>
+            </div>
+        </div>
+    </section>
     
     <section class="features" id="fixture-analysis">
         <div class="container">
@@ -1016,26 +1291,6 @@
                             <li>No Ad-Free Experience</li>
                         </ul>
                         <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Get Started Free</a>
-                    </div>
-                </div>
-                
-                <div class="price-card popular">
-                    <div class="popular">Most Popular</div>
-                    <div class="price-header">
-                        <h3>Premium</h3>
-                        <div class="price">£4.99 <span>/ month</span></div>
-                    </div>
-                    <div class="price-body">
-                        <p>Full access to all features & tools.</p>
-                        <ul class="price-features">
-                            <li>Advanced Player Projections</li>
-                            <li>Multi-Gameweek Transfer Solver</li>
-                            <li>Captaincy & Team Optimization</li>
-                            <li>Live Rank & Bonus Points</li>
-                            <li>Rival Comparison</li>
-                            <li>Ad-Free Experience</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Go Premium</a>
                     </div>
                 </div>
                 

--- a/script.js
+++ b/script.js
@@ -5,11 +5,29 @@ let allElementTypesData = []; // For storing player position/type data
 let currentGameweek = null;
 
 const FPL_BOOTSTRAP_URL = 'https://fantasy.premierleague.com/api/bootstrap-static/';
-// const CORS_PROXY_URL = '/api/fplproxy?url='; 
+// const CORS_PROXY_URL = '/api/fplproxy?url=';
+
+// --- Team Planner Constants & Variables ---
+const MAX_PLAYERS = 15;
+const MAX_BUDGET = 1000; // Represents 100.0m
+// Adjusted to use singular_name_short from API for consistency
+const PLAYERS_PER_POSITION = { 'GKP': 2, 'DEF': 5, 'MID': 5, 'FWD': 3 };
+const MAX_PLAYERS_FROM_TEAM = 3;
+
+let currentSquad = [];
+let currentBudget = MAX_BUDGET;
 
 // --- DOM Element References ---
+// Analysis Section
 let teamIdInput, fetchTeamButton, loadingIndicator, userTeamSquad, userTeamEpNext, suggestionsContent;
-let rivalTeamIdInput, compareTeamButton, rivalLoadingIndicator, comparisonResults; // For rival comparison
+let rivalTeamIdInput, compareTeamButton, rivalLoadingIndicator, comparisonResults; 
+
+// Team Planner Section
+let positionFilter, playerListTbody, budgetRemainingEl, totalPlayersSelectedEl;
+let squadGoalkeepersUl, squadDefendersUl, squadMidfieldersUl, squadForwardsUl;
+let gkCountEl, defCountEl, midCountEl, fwdCountEl;
+let resetSquadButton;
+
 
 document.addEventListener('DOMContentLoaded', () => {
     // User team analysis elements
@@ -26,6 +44,21 @@ document.addEventListener('DOMContentLoaded', () => {
     rivalLoadingIndicator = document.getElementById('rivalLoadingIndicator');
     comparisonResults = document.getElementById('comparisonResults');
 
+    // Team Planner elements
+    positionFilter = document.getElementById('position-filter');
+    playerListTbody = document.getElementById('player-list-tbody');
+    budgetRemainingEl = document.getElementById('budget-remaining');
+    totalPlayersSelectedEl = document.getElementById('total-players-selected');
+    squadGoalkeepersUl = document.getElementById('squad-goalkeepers');
+    squadDefendersUl = document.getElementById('squad-defenders');
+    squadMidfieldersUl = document.getElementById('squad-midfielders');
+    squadForwardsUl = document.getElementById('squad-forwards');
+    gkCountEl = document.getElementById('gk-count');
+    defCountEl = document.getElementById('def-count');
+    midCountEl = document.getElementById('mid-count');
+    fwdCountEl = document.getElementById('fwd-count');
+    resetSquadButton = document.getElementById('reset-squad-button');
+
     if (fetchTeamButton) {
         fetchTeamButton.addEventListener('click', handleAnalyseTeamClick);
     } else {
@@ -37,6 +70,8 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         console.error("Compare Team Button not found on page load.");
     }
+
+    // Team planner specific listeners are set up in initializeTeamPlanner after data is loaded
 });
 
 
@@ -93,6 +128,10 @@ async function initializeApp() {
             console.log(`Players loaded: ${allPlayersData.length}`);
             console.log(`Teams loaded: ${allTeamsData.length}`);
             console.log(`Element Types loaded: ${allElementTypesData.length}`);
+
+            // Initialize the team planner once data is ready
+            initializeTeamPlanner();
+
         } else {
             console.error("Bootstrap data is not in the expected format or is missing key parts.", bootstrapData);
             throw new Error("Invalid bootstrap data structure.");
@@ -101,6 +140,8 @@ async function initializeApp() {
     } catch (error) {
         console.error("Failed to initialize the application:", error);
         if(userTeamSquad) userTeamSquad.innerHTML = `<p class="error-message">Failed to load initial FPL data: ${error.message}. Please try refreshing.</p>`;
+        // Also inform planner users if data fails to load
+        if(playerListTbody) playerListTbody.innerHTML = `<tr><td colspan="7" class="error-message">Failed to load player data: ${error.message}. Please try refreshing.</td></tr>`;
     }
 }
 
@@ -413,6 +454,269 @@ function isPlayerAvailable(playerObject) {
     const isDoubtfulButMaybePlays = playerObject.status === 'd' && (playerObject.chance_of_playing_next_round === null || playerObject.chance_of_playing_next_round >= 50);
     return isAvailableStatus || isDoubtfulButMaybePlays;
 }
+
+
+// --- Team Planner Functions ---
+
+/**
+ * Maps FPL API element_type IDs to the short names used in the filter ('GKP', 'DEF', 'MID', 'FWD').
+ * And vice-versa. Also maps filter values ('All', 'GK', 'DEF', 'MID', 'FWD') to API element_type IDs or 'all'.
+ */
+const positionMap = {
+    // Mapping from element_type ID to singular_name_short (used internally)
+    1: 'GKP',
+    2: 'DEF',
+    3: 'MID',
+    4: 'FWD',
+    // Mapping from filter value to element_type ID (or 'all')
+    'all': 'all', // Special case for filter
+    'GK': 1,  // User-friendly filter value 'GK' maps to 'GKP' (element_type 1)
+    'DEF': 2,
+    'MID': 3,
+    'FWD': 4,
+    // Mapping from singular_name_short to element_type ID (for convenience)
+    'GKP': 1,
+    'DEFF': 2, // Typo, should be DEF
+    'MIDD': 3, // Typo, should be MID
+    'FWDD': 4  // Typo, should be FWD
+};
+
+// Correcting typos in positionMap
+positionMap['DEF'] = 2;
+positionMap['MID'] = 3;
+positionMap['FWD'] = 4;
+
+
+/**
+ * Initializes the team planner section.
+ * Sets up event listeners and populates the initial player table.
+ */
+function initializeTeamPlanner() {
+    if (!allPlayersData.length || !allElementTypesData.length || !allTeamsData.length) {
+        console.error("Team planner cannot initialize: FPL data not fully loaded.");
+        if (playerListTbody) playerListTbody.innerHTML = `<tr><td colspan="7" class="error-message">Player data could not be loaded for the planner. Try refreshing.</td></tr>`;
+        return;
+    }
+
+    if (positionFilter) {
+        positionFilter.addEventListener('change', populatePlayerTable);
+    } else {
+        console.error("Position filter element not found for planner.");
+    }
+
+    if (resetSquadButton) {
+        resetSquadButton.addEventListener('click', resetSquad);
+    } else {
+        console.error("Reset squad button not found for planner.");
+    }
+    
+    populatePlayerTable(); // Initial population
+    updateSquadDisplay();  // Initial UI update for budget, counts etc.
+    console.log("Team Planner Initialized.");
+}
+
+/**
+ * Populates the player list table based on selected filters.
+ */
+function populatePlayerTable() {
+    if (!playerListTbody || !allPlayersData.length || !allElementTypesData.length || !allTeamsData.length) {
+        console.error("Cannot populate player table: missing elements or data.");
+        if (playerListTbody) playerListTbody.innerHTML = '<tr><td colspan="7">Error loading player data.</td></tr>';
+        return;
+    }
+    playerListTbody.innerHTML = ''; // Clear existing rows
+
+    const selectedFilterValue = positionFilter ? positionFilter.value : 'all'; // e.g., 'GK', 'DEF', 'all'
+    
+    let filteredPlayers = allPlayersData;
+
+    if (selectedFilterValue !== 'all') {
+        const targetElementTypeId = positionMap[selectedFilterValue]; // Get the numeric ID (1, 2, 3, 4)
+        if (targetElementTypeId) {
+            filteredPlayers = allPlayersData.filter(player => player.element_type === targetElementTypeId);
+        } else {
+            console.warn(`Unknown position filter value: ${selectedFilterValue}`);
+        }
+    }
+
+    // Further sort by total_points (desc) as a default sorting for the table
+    filteredPlayers.sort((a, b) => (b.total_points || 0) - (a.total_points || 0));
+
+
+    filteredPlayers.forEach(player => {
+        const team = allTeamsData.find(t => t.id === player.team);
+        const teamShortName = team ? team.short_name : 'N/A';
+        
+        // Get the API's short name for position (GKP, DEF, MID, FWD)
+        const positionApiShortName = positionMap[player.element_type]; 
+
+        const price = (player.now_cost / 10).toFixed(1);
+        const totalPointsLastSeason = player.total_points || 0;
+        const recentPoints = player.form || '0'; // Use form for "Recent Pts*"
+
+        const row = playerListTbody.insertRow();
+        row.innerHTML = `
+            <td>${player.web_name}</td>
+            <td>${teamShortName}</td>
+            <td>${positionApiShortName}</td> 
+            <td>${price}</td>
+            <td>${totalPointsLastSeason}</td>
+            <td>${recentPoints}</td>
+            <td><button class="player-add-button" data-player-id="${player.id}">Add</button></td>
+        `;
+        const addButton = row.querySelector('.player-add-button');
+        if (addButton) {
+            addButton.addEventListener('click', () => addPlayerToSquad(player.id));
+            // Disable button if player is already in squad
+            if (currentSquad.find(p => p.id === player.id)) {
+                addButton.disabled = true;
+                addButton.textContent = 'Added';
+            }
+        }
+    });
+    if(filteredPlayers.length === 0 && playerListTbody){
+        playerListTbody.innerHTML = `<tr><td colspan="7">No players found for position: ${selectedFilterValue}.</td></tr>`;
+    }
+}
+
+/**
+ * Updates the squad display (budget, player counts, lists).
+ */
+function updateSquadDisplay() {
+    if (budgetRemainingEl) {
+        budgetRemainingEl.textContent = (currentBudget / 10).toFixed(1);
+    }
+    if (totalPlayersSelectedEl) {
+        totalPlayersSelectedEl.textContent = currentSquad.length;
+    }
+
+    // Clear current lists
+    if(squadGoalkeepersUl) squadGoalkeepersUl.innerHTML = '';
+    if(squadDefendersUl) squadDefendersUl.innerHTML = '';
+    if(squadMidfieldersUl) squadMidfieldersUl.innerHTML = '';
+    if(squadForwardsUl) squadForwardsUl.innerHTML = '';
+
+    const positionCounts = { 'GKP': 0, 'DEF': 0, 'MID': 0, 'FWD': 0 };
+
+    currentSquad.forEach(player => {
+        const playerDetails = getPlayerDetailsById(player.id); // Ensure we use the full player object from allPlayersData
+        if (!playerDetails) return;
+
+        const positionApiShortName = positionMap[playerDetails.element_type]; // 'GKP', 'DEF', etc.
+        positionCounts[positionApiShortName]++;
+
+        const listItem = document.createElement('li');
+        listItem.innerHTML = `
+            <span class="player-name">${playerDetails.web_name}</span> 
+            (<span class="player-price">£${(playerDetails.now_cost / 10).toFixed(1)}m</span>)
+            <button class="remove-player-btn" data-player-id="${playerDetails.id}">X</button>
+        `;
+        
+        const removeButton = listItem.querySelector('.remove-player-btn');
+        if (removeButton) {
+            removeButton.addEventListener('click', () => removePlayerFromSquad(playerDetails.id));
+        }
+
+        switch (positionApiShortName) {
+            case 'GKP': squadGoalkeepersUl.appendChild(listItem); break;
+            case 'DEF': squadDefendersUl.appendChild(listItem); break;
+            case 'MID': squadMidfieldersUl.appendChild(listItem); break;
+            case 'FWD': squadForwardsUl.appendChild(listItem); break;
+        }
+    });
+
+    if (gkCountEl) gkCountEl.textContent = positionCounts['GKP'];
+    if (defCountEl) defCountEl.textContent = positionCounts['DEF'];
+    if (midCountEl) midCountEl.textContent = positionCounts['MID'];
+    if (fwdCountEl) fwdCountEl.textContent = positionCounts['FWD'];
+
+    // Refresh player table to update "Add" button states
+    // This is important if a player is removed, their "Add" button should be re-enabled.
+    populatePlayerTable();
+}
+
+/**
+ * Adds a player to the current squad if validation checks pass.
+ * @param {number} playerId The ID of the player to add.
+ */
+function addPlayerToSquad(playerId) {
+    const player = getPlayerDetailsById(playerId);
+    if (!player) {
+        console.error(`Player with ID ${playerId} not found.`);
+        return;
+    }
+
+    // --- Validations ---
+    // 1. Squad full
+    if (currentSquad.length >= MAX_PLAYERS) {
+        alert("Squad is full (15 players max).");
+        return;
+    }
+    // 2. Budget
+    if (currentBudget < player.now_cost) {
+        alert(`Not enough budget. Remaining: £${(currentBudget / 10).toFixed(1)}m, Player cost: £${(player.now_cost / 10).toFixed(1)}m`);
+        return;
+    }
+    // 3. Player already in squad
+    if (currentSquad.find(p => p.id === playerId)) {
+        alert(`${player.web_name} is already in your squad.`);
+        return;
+    }
+
+    const playerPositionApiShortName = positionMap[player.element_type]; // 'GKP', 'DEF', etc.
+    
+    // 4. Max players for this position
+    const playersInPosition = currentSquad.filter(p => p.element_type === player.element_type);
+    if (playersInPosition.length >= PLAYERS_PER_POSITION[playerPositionApiShortName]) {
+        alert(`Max players for position ${playerPositionApiShortName} (${PLAYERS_PER_POSITION[playerPositionApiShortName]}) reached.`);
+        return;
+    }
+
+    // 5. Max players from the same team
+    const playersFromSameTeam = currentSquad.filter(p => p.team === player.team);
+    if (playersFromSameTeam.length >= MAX_PLAYERS_FROM_TEAM) {
+        alert(`Max ${MAX_PLAYERS_FROM_TEAM} players from the same team (${allTeamsData.find(t => t.id === player.team)?.name || 'N/A'}).`);
+        return;
+    }
+
+    // --- Add player ---
+    currentSquad.push(player); // Store the full player object
+    currentBudget -= player.now_cost;
+    
+    console.log(`${player.web_name} added to squad. Budget remaining: ${(currentBudget / 10).toFixed(1)}m`);
+    updateSquadDisplay(); // This will also call populatePlayerTable to update button states
+}
+
+/**
+ * Removes a player from the current squad.
+ * @param {number} playerId The ID of the player to remove.
+ */
+function removePlayerFromSquad(playerId) {
+    const playerIndex = currentSquad.findIndex(p => p.id === playerId);
+    if (playerIndex > -1) {
+        const player = currentSquad[playerIndex];
+        currentBudget += player.now_cost;
+        currentSquad.splice(playerIndex, 1);
+        
+        console.log(`${player.web_name} removed from squad. Budget remaining: ${(currentBudget / 10).toFixed(1)}m`);
+        updateSquadDisplay(); // This will also call populatePlayerTable to re-enable the Add button
+    } else {
+        console.warn(`Player with ID ${playerId} not found in current squad for removal.`);
+    }
+}
+
+
+/**
+ * Resets the current squad to empty and full budget.
+ */
+function resetSquad() {
+    console.log("Resetting squad...");
+    currentSquad = [];
+    currentBudget = MAX_BUDGET;
+    updateSquadDisplay(); // This will call populatePlayerTable, which handles button states
+    console.log("Squad has been reset.");
+}
+
 
 // Call initializeApp when the script loads
 initializeApp();


### PR DESCRIPTION
Implements a new '25/26 Planner' section allowing you to build a 15-player squad (2 GK, 5 DEF, 5 MID, 3 FWD) within a £100m budget.

Key features of the planner:
- Player list table displaying name, team, position, price, total points last season, and form.
- Filtering players by position.
- Adding/removing players to/from the squad.
- Real-time budget updates.
- Validation for squad composition (player counts per position, max 15 players).
- Validation for max 3 players from a single Premier League team.
- Reset squad functionality.
- 'Add' buttons in the player list are disabled/enabled based on squad membership.

Additionally, this change removes the 'Premium' pricing card from the pricing section as you requested.

A navigation link '25/26 Planner' has been added to the header.