### PR TITLE
Refactor: Move Analyser and 25/26 Planner to separate pages

### DIFF
--- a/analyser.html
+++ b/analyser.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FPL Optimised - The Holy Grail of FPL Tools</title>
+    <title>FPL Optimised - Analyser</title>
     <style>
         :root {
             --primary: #37003c;
@@ -906,12 +906,12 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="#features">Features</a></li>
-                    <li><a href="#predictions">Predictions</a></li>
-                    <li><a href="#live-tools">Live Tools</a></li>
+                    <li><a href="index.html#features">Features</a></li>
+                    <li><a href="index.html#predictions">Predictions</a></li>
+                    <li><a href="index.html#live-tools">Live Tools</a></li>
                     <li><a href="analyser.html">Analyse</a></li>
                     <li><a href="planner.html">25/26 Planner</a></li>
-                    <li><a href="#pricing">Pricing</a></li>
+                    <li><a href="index.html#pricing">Pricing</a></li>
                 </ul>
             </nav>
             <div class="auth-buttons">
@@ -921,316 +921,49 @@
         </div>
     </header>
     
-    <section class="hero">
-        <div class="container">
-            <div class="hero-content">
-                <h1>The Holy Grail of FPL Tools</h1>
-                <p>All-in-one platform with advanced projections, live tracking, and strategy analysis to boost your Fantasy Premier League performance.</p>
-                <a href="#" class="btn btn-primary">Start Your Free Trial</a>
-            </div>
-        </div>
-    </section>
-    
-    <section class="features" id="features">
-        <div class="container">
+    <section class="dashboard-demo" id="analysis">
+        <div class="container"> <!-- Use existing container class for consistent styling -->
             <div class="section-title">
-                <h2>Comprehensive FPL Toolkit</h2>
-                <p>Everything you need to dominate your mini-leagues and climb the global rankings</p>
+                <h2>Analyse Your FPL Team</h2>
+                <p>Enter your FPL Team ID to get optimisation suggestions and compare with rivals.</p>
             </div>
-            
-            <div class="feature-grid">
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Advanced Predictions & Planning</h3>
-                        <p>Data-driven player projections and optimization tools</p>
-                        <ul class="feature-list">
-                            <li>Advanced Player Projections</li>
-                            <li>Multi-Gameweek Transfer Solver</li>
-                            <li>Captaincy & Team Optimization</li>
-                            <li>Scenario Simulation</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Strategy & Retrospective Analysis</h3>
-                        <p>Learn from past performances and elite managers</p>
-                        <ul class="feature-list">
-                            <li>Season Review Tool</li>
-                            <li>Elite Manager Data</li>
-                            <li>HiveMind Custom Projections</li>
-                            <li>Performance Insights</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Live & In-Season Tools</h3>
-                        <p>Real-time updates during gameweeks</p>
-                        <ul class="feature-list">
-                            <li>Live Rank Tracking</li>
-                            <li>Live Bonus Points Tracker</li>
-                            <li>Price Change Predictor</li>
-                            <li>Live League Standings</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Fixture Analysis & Scheduling</h3>
-                        <p>Plan ahead with comprehensive fixture tools</p>
-                        <ul class="feature-list">
-                            <li>Fixture Difficulty Rating Charts</li>
-                            <li>Team Fixture Planning Tools</li>
-                            <li>Rotation Pair Analysis</li>
-                            <li>Season Ticker</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Team & Player Analysis</h3>
-                        <p>Detailed stats on your team and players</p>
-                        <ul class="feature-list">
-                            <li>Team Analyzer Dashboards</li>
-                            <li>Captaincy Success Rates</li>
-                            <li>Transfer Success Tracker</li>
-                            <li>Player Comparison</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>UX Enhancements & Integrations</h3>
-                        <p>Seamless experience across devices</p>
-                        <ul class="feature-list">
-                            <li>Browser Extensions</li>
-                            <li>Mobile-Friendly Dashboards</li>
-                            <li>Auto Team Import</li>
-                            <li>Custom Notifications</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <section class="dashboard-preview" id="predictions">
-        <div class="container">
-            <div class="section-title">
-                <h2>Advanced Prediction & Planning Tools</h2>
-                <p>Make data-driven decisions with our comprehensive prediction suite</p>
-            </div>
-            
-            <div class="demo-tabs">
-                <div class="demo-tab active">Player Projections</div>
-                <div class="demo-tab">Transfer Solver</div>
-                <div class="demo-tab">Captaincy Optimizer</div>
-                <div class="demo-tab">Scenario Simulation</div>
-            </div>
-            
-            <div class="demo-content">
-                <img src="/api/placeholder/1000/600" alt="Player Projections Dashboard" class="demo-screen">
-                <div style="margin-top: 2rem;">
-                    <h3>Advanced Player Projections</h3>
-                    <p>Our state-of-the-art prediction model combines underlying statistics, expected goals (xG), expected assists (xA), and bookie odds to provide the most accurate player projections available.</p>
-                    <div style="display: flex; flex-wrap: wrap; margin-top: 1.5rem;">
-                        <div style="flex: 1; min-width: 200px; margin-right: 1rem; margin-bottom: 1rem;">
-                            <h4>Data-Driven Analysis</h4>
-                            <p>Projections based on thousands of data points, updated after every match.</p>
-                        </div>
-                        <div style="flex: 1; min-width: 200px; margin-right: 1rem; margin-bottom: 1rem;">
-                            <h4>Position-Specific Metrics</h4>
-                            <p>Different metrics weighted appropriately based on player positions.</p>
-                        </div>
-                        <div style="flex: 1; min-width: 200px; margin-bottom: 1rem;">
-                            <h4>Form & Fixture Adjusted</h4>
-                            <p>Accounts for recent player form and upcoming fixture difficulty.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <section class="live-tools" id="live-tools">
-        <div class="container">
-            <div class="section-title">
-                <h2>Live & In-Season Tools</h2>
-                <p>Stay ahead with real-time updates during gameweeks</p>
-            </div>
-            
-            <div class="feature-grid">
-                <div class="tool-card">
-                    <div class="tool-icon">📊</div>
-                    <h3>Live Rank Tracking</h3>
-                    <p>Watch your overall rank and mini-league positions change in real-time as matches unfold. No more waiting for official updates.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">🏆</div>
-                    <h3>Live Bonus Points Tracker</h3>
-                    <p>Get accurate predictions of bonus point allocations during matches based on the official BPS calculation system.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">💰</div>
-                    <h3>Price Change Predictor</h3>
-                    <p>Never miss a price rise or fall again with our accurate algorithm that predicts player price changes.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">🏅</div>
-                    <h3>Live League Standings</h3>
-                    <p>See how your mini-league standings evolve in real-time, with detailed breakdowns of each manager's points.</p>
-                </div>
-            </div>
-            
-            <div style="text-align: center; margin-top: 3rem;">
-                <img src="/api/placeholder/1000/500" alt="Live FPL Dashboard" style="max-width: 100%; border-radius: 8px; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);">
-            </div>
-        </div>
-    </section>
-    
-    <section class="features" id="fixture-analysis">
-        <div class="container">
-            <div class="section-title">
-                <h2>Fixture Analysis & Scheduling</h2>
-                <p>Plan ahead with comprehensive fixture tools</p>
-            </div>
-            
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 3rem;">
-                <div>
-                    <img src="/api/placeholder/500/400" alt="FDR Chart" style="width: 100%; border-radius: 8px; box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);">
-                </div>
-                <div>
-                    <h3>Fixture Difficulty Rating (FDR) Charts</h3>
-                    <p>Visualize the ease or difficulty of upcoming fixtures for all Premier League teams with our color-coded charts.</p>
-                    <ul class="feature-list" style="margin-top: 1rem;">
-                        <li>Customizable FDR Parameters</li>
-                        <li>Home & Away Difficulty Breakdown</li>
-                        <li>Rotation Pair Analysis</li>
-                        <li>Long-Term Fixture Planning</li>
-                    </ul>
-                    <a href="#" class="btn btn-primary">Explore FDR Charts</a>
-                </div>
-            </div>
-            
-            <div style="text-align: center; margin-top: 3rem;">
-                <h3>Season Ticker & Planner</h3>
-                <p>Comprehensive view of all upcoming matches, filterable by team and gameweek range.</p>
-                <img src="/api/placeholder/1000/300" alt="Season Ticker" style="width: 100%; max-width: 800px; margin-top: 1rem; border-radius: 8px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);">
-            </div>
-        </div>
-    </section>
-    
-    <section class="pricing" id="pricing">
-        <div class="container">
-            <div class="section-title">
-                <h2>Choose Your Plan</h2>
-                <p>Unlock the full potential of FPL Optimised with our flexible subscription plans.</p>
-            </div>
-            
-            <div class="price-grid">
-                <div class="price-card">
-                    <div class="price-header">
-                        <h3>Free Tier</h3>
-                        <div class="price">£0 <span>/ month</span></div>
-                    </div>
-                    <div class="price-body">
-                        <p>Basic access to core tools.</p>
-                        <ul class="price-features">
-                            <li>Limited Player Projections</li>
-                            <li>Basic Fixture Analysis</li>
-                            <li>Team ID Input (Your Team Only)</li>
-                            <li>No Ad-Free Experience</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Get Started Free</a>
-                    </div>
-                </div>
-                
-                <div class="price-card">
-                    <div class="price-header">
-                        <h3>Annual Saver</h3>
-                        <div class="price">£49.99 <span>/ year</span></div>
-                    </div>
-                    <div class="price-body">
-                        <p>Get 2 months free with annual billing.</p>
-                        <ul class="price-features">
-                            <li>All Premium Features</li>
-                            <li>Priority Support</li>
-                            <li>Early Access to New Tools</li>
-                            <li>Exclusive Community Access</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Choose Annual</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
-    <section class="testimonials">
-        <div class="container">
-            <div class="section-title">
-                <h2>What Our Users Say</h2>
+            <!-- Team Input Area -->
+            <div id="team-input-area" style="margin-bottom: 2rem; padding: 1rem; background-color: #fff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1);">
+                <label for="teamIdInput">Your FPL Team ID:</label>
+                <input type="number" id="teamIdInput" name="teamId" placeholder="Enter your Team ID" style="padding: 0.5rem; margin-right: 0.5rem; border: 1px solid #ccc; border-radius: 4px;">
+                <button id="fetchTeamButton" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary);">Analyse Team</button>
+                <span id="loadingIndicator" style="margin-left: 1rem; display: none;">Loading...</span>
             </div>
-            <div class="testimonial-grid">
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"FPL Optimised changed the game for me. The transfer solver is pure magic!"</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>ManagerX123</h4>
-                            <p>Top 10k Finish 2022/23</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"The live rank tracking is incredibly addictive and so much faster than the official site."</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>FPL_Guruette</h4>
-                            <p>Consistent Top 50k Manager</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"I finally beat my mini-league rivals thanks to the detailed analysis and head-to-head comparison."</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>RivalSlayer99</h4>
-                            <p>Mini-League Champion</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
-    <section class="cta">
-        <div class="container">
-            <h2>Ready to Elevate Your FPL Game?</h2>
-            <p>Join thousands of managers who are already using FPL Optimised to gain an edge. Sign up for your free trial today and start making smarter FPL decisions.</p>
-            <a href="#" class="btn btn-primary" style="font-size: 1.2rem; padding: 0.8rem 2rem;">Sign Up & Get Started</a>
+            <!-- User Team Display Area -->
+            <div id="userTeamDisplay" style="margin-bottom: 2rem; padding: 1rem; background-color: #f8f9fa; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
+                <h3>Your Current Team</h3>
+                <div id="userTeamSquad">
+                    <!-- User's squad will be displayed here by JavaScript -->
+                </div>
+                <p>Total Expected Points (Next GW): <span id="userTeamEpNext">N/A</span></p>
+            </div>
+
+            <!-- Optimisation Suggestions Area -->
+            <div id="optimisationSuggestions" style="margin-bottom: 2rem; padding: 1rem; background-color: #f8f9fa; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
+                <h3>Optimisation Suggestions</h3>
+                <div id="suggestionsContent">
+                    <!-- Transfer suggestions will be displayed here by JavaScript -->
+                </div>
+            </div>
+
+            <!-- Rival Comparison Area -->
+            <div id="rival-comparison-area" style="padding: 1rem; background-color: #fff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1);">
+                <h3>Compare with Rival</h3>
+                <label for="rivalTeamIdInput">Rival's FPL Team ID:</label>
+                <input type="number" id="rivalTeamIdInput" name="rivalTeamId" placeholder="Enter Rival's Team ID" style="padding: 0.5rem; margin-right: 0.5rem; border: 1px solid #ccc; border-radius: 4px;">
+                <button id="compareTeamButton" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary);">Compare</button>
+                <span id="rivalLoadingIndicator" style="margin-left: 1rem; display: none;">Loading rival...</span>
+                <div id="comparisonResults" style="margin-top: 1rem;">
+                    <!-- Comparison results will be displayed here by JavaScript -->
+                </div>
+            </div>
         </div>
     </section>
 
@@ -1244,8 +977,8 @@
                 <div class="footer-col">
                     <h3>Quick Links</h3>
                     <ul>
-                        <li><a href="#features">Features</a></li>
-                        <li><a href="#pricing">Pricing</a></li>
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
                         <li><a href="#">FAQs</a></li>
                         <li><a href="#">Contact Us</a></li>
                     </ul>

--- a/planner.html
+++ b/planner.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>FPL Optimised - The Holy Grail of FPL Tools</title>
+    <title>FPL Optimised - 25/26 Planner</title>
     <style>
         :root {
             --primary: #37003c;
@@ -906,12 +906,12 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="#features">Features</a></li>
-                    <li><a href="#predictions">Predictions</a></li>
-                    <li><a href="#live-tools">Live Tools</a></li>
+                    <li><a href="index.html#features">Features</a></li>
+                    <li><a href="index.html#predictions">Predictions</a></li>
+                    <li><a href="index.html#live-tools">Live Tools</a></li>
                     <li><a href="analyser.html">Analyse</a></li>
                     <li><a href="planner.html">25/26 Planner</a></li>
-                    <li><a href="#pricing">Pricing</a></li>
+                    <li><a href="index.html#pricing">Pricing</a></li>
                 </ul>
             </nav>
             <div class="auth-buttons">
@@ -921,316 +921,85 @@
         </div>
     </header>
     
-    <section class="hero">
-        <div class="container">
-            <div class="hero-content">
-                <h1>The Holy Grail of FPL Tools</h1>
-                <p>All-in-one platform with advanced projections, live tracking, and strategy analysis to boost your Fantasy Premier League performance.</p>
-                <a href="#" class="btn btn-primary">Start Your Free Trial</a>
-            </div>
-        </div>
-    </section>
-    
-    <section class="features" id="features">
+     <section class="dashboard-demo" id="team-planner-section">
         <div class="container">
             <div class="section-title">
-                <h2>Comprehensive FPL Toolkit</h2>
-                <p>Everything you need to dominate your mini-leagues and climb the global rankings</p>
+                <h2>25/26 Planner</h2>
+                <p>Plan your dream squad for the next Fantasy Premier League season.</p>
             </div>
-            
-            <div class="feature-grid">
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Advanced Predictions & Planning</h3>
-                        <p>Data-driven player projections and optimization tools</p>
-                        <ul class="feature-list">
-                            <li>Advanced Player Projections</li>
-                            <li>Multi-Gameweek Transfer Solver</li>
-                            <li>Captaincy & Team Optimization</li>
-                            <li>Scenario Simulation</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
+
+            <!-- Main content area for the planner -->
+            <div class="planner-content">
+
+                <!-- Left side: Player selection table and filters -->
+                <div class="player-selection-area">
+                    <h3>Available Players</h3>
+                    <div class="filters-sort">
+                        <!-- Position Filter -->
+                        <label for="position-filter">Position:</label>
+                        <select id="position-filter">
+                            <option value="all">All</option>
+                            <option value="GK">Goalkeepers (GK)</option>
+                            <option value="DEF">Defenders (DEF)</option>
+                            <option value="MID">Midfielders (MID)</option>
+                            <option value="FWD">Forwards (FWD)</option>
+                        </select>
+                        <!-- Sorting (to be implemented later if needed via JS) -->
+                    </div>
+                    <div class="player-list-table-container">
+                        <table id="player-list-table">
+                            <thead>
+                                <tr>
+                                    <th>Player</th>
+                                    <th>Team</th>
+                                    <th>Pos.</th>
+                                    <th>Price (£m)</th>
+                                    <th>Total Pts (LS)</th>
+                                    <th>Recent Pts*</th>
+                                    <th>Add</th>
+                                </tr>
+                            </thead>
+                            <tbody id="player-list-tbody">
+                                <!-- Player rows will be dynamically inserted here by JavaScript -->
+                            </tbody>
+                        </table>
+                        <p><small>*Recent Pts refers to form or last few gameweeks' average if available.</small></p>
                     </div>
                 </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Strategy & Retrospective Analysis</h3>
-                        <p>Learn from past performances and elite managers</p>
-                        <ul class="feature-list">
-                            <li>Season Review Tool</li>
-                            <li>Elite Manager Data</li>
-                            <li>HiveMind Custom Projections</li>
-                            <li>Performance Insights</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
+
+                <!-- Right side: Squad display and budget information -->
+                <div class="squad-summary-area">
+                    <h3>Your Squad</h3>
+                    <div class="budget-info">
+                        <span>Budget: £</span><span id="budget-remaining">100.0</span>m
                     </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Live & In-Season Tools</h3>
-                        <p>Real-time updates during gameweeks</p>
-                        <ul class="feature-list">
-                            <li>Live Rank Tracking</li>
-                            <li>Live Bonus Points Tracker</li>
-                            <li>Price Change Predictor</li>
-                            <li>Live League Standings</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
+                    <div class="squad-composition-info">
+                        <span>Players: </span><span id="total-players-selected">0</span>/15
                     </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Fixture Analysis & Scheduling</h3>
-                        <p>Plan ahead with comprehensive fixture tools</p>
-                        <ul class="feature-list">
-                            <li>Fixture Difficulty Rating Charts</li>
-                            <li>Team Fixture Planning Tools</li>
-                            <li>Rotation Pair Analysis</li>
-                            <li>Season Ticker</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>Team & Player Analysis</h3>
-                        <p>Detailed stats on your team and players</p>
-                        <ul class="feature-list">
-                            <li>Team Analyzer Dashboards</li>
-                            <li>Captaincy Success Rates</li>
-                            <li>Transfer Success Tracker</li>
-                            <li>Player Comparison</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-                
-                <div class="feature-card">
-                    <div class="feature-img" style="background-image: url('/api/placeholder/400/200')"></div>
-                    <div class="feature-content">
-                        <h3>UX Enhancements & Integrations</h3>
-                        <p>Seamless experience across devices</p>
-                        <ul class="feature-list">
-                            <li>Browser Extensions</li>
-                            <li>Mobile-Friendly Dashboards</li>
-                            <li>Auto Team Import</li>
-                            <li>Custom Notifications</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary">Learn More</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <section class="dashboard-preview" id="predictions">
-        <div class="container">
-            <div class="section-title">
-                <h2>Advanced Prediction & Planning Tools</h2>
-                <p>Make data-driven decisions with our comprehensive prediction suite</p>
-            </div>
-            
-            <div class="demo-tabs">
-                <div class="demo-tab active">Player Projections</div>
-                <div class="demo-tab">Transfer Solver</div>
-                <div class="demo-tab">Captaincy Optimizer</div>
-                <div class="demo-tab">Scenario Simulation</div>
-            </div>
-            
-            <div class="demo-content">
-                <img src="/api/placeholder/1000/600" alt="Player Projections Dashboard" class="demo-screen">
-                <div style="margin-top: 2rem;">
-                    <h3>Advanced Player Projections</h3>
-                    <p>Our state-of-the-art prediction model combines underlying statistics, expected goals (xG), expected assists (xA), and bookie odds to provide the most accurate player projections available.</p>
-                    <div style="display: flex; flex-wrap: wrap; margin-top: 1.5rem;">
-                        <div style="flex: 1; min-width: 200px; margin-right: 1rem; margin-bottom: 1rem;">
-                            <h4>Data-Driven Analysis</h4>
-                            <p>Projections based on thousands of data points, updated after every match.</p>
-                        </div>
-                        <div style="flex: 1; min-width: 200px; margin-right: 1rem; margin-bottom: 1rem;">
-                            <h4>Position-Specific Metrics</h4>
-                            <p>Different metrics weighted appropriately based on player positions.</p>
-                        </div>
-                        <div style="flex: 1; min-width: 200px; margin-bottom: 1rem;">
-                            <h4>Form & Fixture Adjusted</h4>
-                            <p>Accounts for recent player form and upcoming fixture difficulty.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    
-    <section class="live-tools" id="live-tools">
-        <div class="container">
-            <div class="section-title">
-                <h2>Live & In-Season Tools</h2>
-                <p>Stay ahead with real-time updates during gameweeks</p>
-            </div>
-            
-            <div class="feature-grid">
-                <div class="tool-card">
-                    <div class="tool-icon">📊</div>
-                    <h3>Live Rank Tracking</h3>
-                    <p>Watch your overall rank and mini-league positions change in real-time as matches unfold. No more waiting for official updates.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">🏆</div>
-                    <h3>Live Bonus Points Tracker</h3>
-                    <p>Get accurate predictions of bonus point allocations during matches based on the official BPS calculation system.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">💰</div>
-                    <h3>Price Change Predictor</h3>
-                    <p>Never miss a price rise or fall again with our accurate algorithm that predicts player price changes.</p>
-                </div>
-                
-                <div class="tool-card">
-                    <div class="tool-icon">🏅</div>
-                    <h3>Live League Standings</h3>
-                    <p>See how your mini-league standings evolve in real-time, with detailed breakdowns of each manager's points.</p>
-                </div>
-            </div>
-            
-            <div style="text-align: center; margin-top: 3rem;">
-                <img src="/api/placeholder/1000/500" alt="Live FPL Dashboard" style="max-width: 100%; border-radius: 8px; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);">
-            </div>
-        </div>
-    </section>
-    
-    <section class="features" id="fixture-analysis">
-        <div class="container">
-            <div class="section-title">
-                <h2>Fixture Analysis & Scheduling</h2>
-                <p>Plan ahead with comprehensive fixture tools</p>
-            </div>
-            
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 3rem;">
-                <div>
-                    <img src="/api/placeholder/500/400" alt="FDR Chart" style="width: 100%; border-radius: 8px; box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);">
-                </div>
-                <div>
-                    <h3>Fixture Difficulty Rating (FDR) Charts</h3>
-                    <p>Visualize the ease or difficulty of upcoming fixtures for all Premier League teams with our color-coded charts.</p>
-                    <ul class="feature-list" style="margin-top: 1rem;">
-                        <li>Customizable FDR Parameters</li>
-                        <li>Home & Away Difficulty Breakdown</li>
-                        <li>Rotation Pair Analysis</li>
-                        <li>Long-Term Fixture Planning</li>
+
+                    <!-- Squad display separated by positions -->
+                    <h4>Goalkeepers (<span id="gk-count">0</span>/2)</h4>
+                    <ul id="squad-goalkeepers" class="squad-position-list">
+                        <!-- Selected GKs will be listed here -->
                     </ul>
-                    <a href="#" class="btn btn-primary">Explore FDR Charts</a>
-                </div>
-            </div>
-            
-            <div style="text-align: center; margin-top: 3rem;">
-                <h3>Season Ticker & Planner</h3>
-                <p>Comprehensive view of all upcoming matches, filterable by team and gameweek range.</p>
-                <img src="/api/placeholder/1000/300" alt="Season Ticker" style="width: 100%; max-width: 800px; margin-top: 1rem; border-radius: 8px; box-shadow: 0 4px 15px rgba(0,0,0,0.1);">
-            </div>
-        </div>
-    </section>
-    
-    <section class="pricing" id="pricing">
-        <div class="container">
-            <div class="section-title">
-                <h2>Choose Your Plan</h2>
-                <p>Unlock the full potential of FPL Optimised with our flexible subscription plans.</p>
-            </div>
-            
-            <div class="price-grid">
-                <div class="price-card">
-                    <div class="price-header">
-                        <h3>Free Tier</h3>
-                        <div class="price">£0 <span>/ month</span></div>
-                    </div>
-                    <div class="price-body">
-                        <p>Basic access to core tools.</p>
-                        <ul class="price-features">
-                            <li>Limited Player Projections</li>
-                            <li>Basic Fixture Analysis</li>
-                            <li>Team ID Input (Your Team Only)</li>
-                            <li>No Ad-Free Experience</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Get Started Free</a>
-                    </div>
-                </div>
-                
-                <div class="price-card">
-                    <div class="price-header">
-                        <h3>Annual Saver</h3>
-                        <div class="price">£49.99 <span>/ year</span></div>
-                    </div>
-                    <div class="price-body">
-                        <p>Get 2 months free with annual billing.</p>
-                        <ul class="price-features">
-                            <li>All Premium Features</li>
-                            <li>Priority Support</li>
-                            <li>Early Access to New Tools</li>
-                            <li>Exclusive Community Access</li>
-                        </ul>
-                        <a href="#" class="btn btn-primary" style="background-color: var(--primary); color: var(--secondary); width: 100%; text-align: center;">Choose Annual</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
-    <section class="testimonials">
-        <div class="container">
-            <div class="section-title">
-                <h2>What Our Users Say</h2>
-            </div>
-            <div class="testimonial-grid">
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"FPL Optimised changed the game for me. The transfer solver is pure magic!"</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>ManagerX123</h4>
-                            <p>Top 10k Finish 2022/23</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"The live rank tracking is incredibly addictive and so much faster than the official site."</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>FPL_Guruette</h4>
-                            <p>Consistent Top 50k Manager</p>
-                        </div>
-                    </div>
-                </div>
-                <div class="testimonial-card">
-                    <p class="testimonial-text">"I finally beat my mini-league rivals thanks to the detailed analysis and head-to-head comparison."</p>
-                    <div class="testimonial-author">
-                        <div class="author-img" style="background-image: url('/api/placeholder/50/50')"></div>
-                        <div class="author-info">
-                            <h4>RivalSlayer99</h4>
-                            <p>Mini-League Champion</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
+                    <h4>Defenders (<span id="def-count">0</span>/5)</h4>
+                    <ul id="squad-defenders" class="squad-position-list">
+                        <!-- Selected DEFs will be listed here -->
+                    </ul>
 
-    <section class="cta">
-        <div class="container">
-            <h2>Ready to Elevate Your FPL Game?</h2>
-            <p>Join thousands of managers who are already using FPL Optimised to gain an edge. Sign up for your free trial today and start making smarter FPL decisions.</p>
-            <a href="#" class="btn btn-primary" style="font-size: 1.2rem; padding: 0.8rem 2rem;">Sign Up & Get Started</a>
+                    <h4>Midfielders (<span id="mid-count">0</span>/5)</h4>
+                    <ul id="squad-midfielders" class="squad-position-list">
+                        <!-- Selected MIDs will be listed here -->
+                    </ul>
+
+                    <h4>Forwards (<span id="fwd-count">0</span>/3)</h4>
+                    <ul id="squad-forwards" class="squad-position-list">
+                        <!-- Selected FWDs will be listed here -->
+                    </ul>
+                    <button id="reset-squad-button" class="btn btn-danger" style="margin-top: 1rem;">Reset Squad</button>
+                </div>
+            </div>
         </div>
     </section>
 
@@ -1244,8 +1013,8 @@
                 <div class="footer-col">
                     <h3>Quick Links</h3>
                     <ul>
-                        <li><a href="#features">Features</a></li>
-                        <li><a href="#pricing">Pricing</a></li>
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
                         <li><a href="#">FAQs</a></li>
                         <li><a href="#">Contact Us</a></li>
                     </ul>

--- a/script.js
+++ b/script.js
@@ -34,44 +34,45 @@ document.addEventListener('DOMContentLoaded', () => {
     teamIdInput = document.getElementById('teamIdInput');
     fetchTeamButton = document.getElementById('fetchTeamButton');
     loadingIndicator = document.getElementById('loadingIndicator');
+    // Analysis Section Elements
+    teamIdInput = document.getElementById('teamIdInput');
+    fetchTeamButton = document.getElementById('fetchTeamButton');
+    loadingIndicator = document.getElementById('loadingIndicator');
     userTeamSquad = document.getElementById('userTeamSquad');
     userTeamEpNext = document.getElementById('userTeamEpNext');
     suggestionsContent = document.getElementById('suggestionsContent');
-    
-    // Rival comparison elements
     rivalTeamIdInput = document.getElementById('rivalTeamIdInput');
     compareTeamButton = document.getElementById('compareTeamButton');
     rivalLoadingIndicator = document.getElementById('rivalLoadingIndicator');
     comparisonResults = document.getElementById('comparisonResults');
-
-    // Team Planner elements
+    
+    // Rival comparison elements
+    // Team Planner Section Elements
     positionFilter = document.getElementById('position-filter');
-    playerListTbody = document.getElementById('player-list-tbody');
-    budgetRemainingEl = document.getElementById('budget-remaining');
-    totalPlayersSelectedEl = document.getElementById('total-players-selected');
-    squadGoalkeepersUl = document.getElementById('squad-goalkeepers');
-    squadDefendersUl = document.getElementById('squad-defenders');
-    squadMidfieldersUl = document.getElementById('squad-midfielders');
-    squadForwardsUl = document.getElementById('squad-forwards');
-    gkCountEl = document.getElementById('gk-count');
-    defCountEl = document.getElementById('def-count');
-    midCountEl = document.getElementById('mid-count');
-    fwdCountEl = document.getElementById('fwd-count');
-    resetSquadButton = document.getElementById('reset-squad-button');
+    playerListTbody = document.getElementById('player-list-tbody'); // Used in initializeTeamPlanner, populatePlayerTable
+    budgetRemainingEl = document.getElementById('budget-remaining'); // Used in updateSquadDisplay
+    totalPlayersSelectedEl = document.getElementById('total-players-selected'); // Used in updateSquadDisplay
+    squadGoalkeepersUl = document.getElementById('squad-goalkeepers'); // Used in updateSquadDisplay
+    squadDefendersUl = document.getElementById('squad-defenders'); // Used in updateSquadDisplay
+    squadMidfieldersUl = document.getElementById('squad-midfielders'); // Used in updateSquadDisplay
+    squadForwardsUl = document.getElementById('squad-forwards'); // Used in updateSquadDisplay
+    gkCountEl = document.getElementById('gk-count'); // Used in updateSquadDisplay
+    defCountEl = document.getElementById('def-count'); // Used in updateSquadDisplay
+    midCountEl = document.getElementById('mid-count'); // Used in updateSquadDisplay
+    fwdCountEl = document.getElementById('fwd-count'); // Used in updateSquadDisplay
+    resetSquadButton = document.getElementById('reset-squad-button'); // Used in initializeTeamPlanner
 
+    // Event listeners for Analysis page
     if (fetchTeamButton) {
         fetchTeamButton.addEventListener('click', handleAnalyseTeamClick);
-    } else {
-        console.error("Fetch Team Button not found on page load.");
     }
-
     if (compareTeamButton) {
         compareTeamButton.addEventListener('click', handleCompareTeamClick);
-    } else {
-        console.error("Compare Team Button not found on page load.");
     }
 
-    // Team planner specific listeners are set up in initializeTeamPlanner after data is loaded
+    // Team planner specific listeners are primarily set up in initializeTeamPlanner,
+    // which is called after data loading in initializeApp.
+    // No direct listeners here unless they don't depend on fetched data.
 });
 
 
@@ -130,6 +131,7 @@ async function initializeApp() {
             console.log(`Element Types loaded: ${allElementTypesData.length}`);
 
             // Initialize the team planner once data is ready
+            // This function itself should be robust if planner elements are not on the page
             initializeTeamPlanner();
 
         } else {
@@ -139,9 +141,14 @@ async function initializeApp() {
         
     } catch (error) {
         console.error("Failed to initialize the application:", error);
-        if(userTeamSquad) userTeamSquad.innerHTML = `<p class="error-message">Failed to load initial FPL data: ${error.message}. Please try refreshing.</p>`;
-        // Also inform planner users if data fails to load
-        if(playerListTbody) playerListTbody.innerHTML = `<tr><td colspan="7" class="error-message">Failed to load player data: ${error.message}. Please try refreshing.</td></tr>`;
+        // Display error on Analysis page elements if they exist
+        if (userTeamSquad) {
+            userTeamSquad.innerHTML = `<p class="error-message">Failed to load initial FPL data: ${error.message}. Please try refreshing.</p>`;
+        }
+        // Display error on Planner page elements if they exist
+        if (playerListTbody) {
+            playerListTbody.innerHTML = `<tr><td colspan="7" class="error-message">Failed to load player data: ${error.message}. Please try refreshing.</td></tr>`;
+        }
     }
 }
 
@@ -149,6 +156,11 @@ async function initializeApp() {
  * Handles the click event for the "Analyse Team" button.
  */
 async function handleAnalyseTeamClick() {
+    if (!teamIdInput || !fetchTeamButton || !loadingIndicator || !userTeamSquad || !userTeamEpNext || !suggestionsContent) {
+        console.error("One or more analysis DOM elements are missing for handleAnalyseTeamClick.");
+        return;
+    }
+
     const teamID = teamIdInput.value.trim();
 
     if (!teamID) {
@@ -170,8 +182,8 @@ async function handleAnalyseTeamClick() {
     try {
         const teamData = await fetchUserTeam(teamID, currentGameweek);
         if (teamData && teamData.picks) {
-            displayUserTeam(teamData.picks);
-            displayBasicOptimisation(teamData.picks);
+            displayUserTeam(teamData.picks); // This function also needs to be robust
+            displayBasicOptimisation(teamData.picks); // This function also needs to be robust
         } else {
             if (!teamData && userTeamSquad.innerHTML === '') { 
                  userTeamSquad.innerHTML = `<p class="error-message">Could not retrieve team data. Team ID might be invalid or private for the gameweek.</p>`;
@@ -183,9 +195,13 @@ async function handleAnalyseTeamClick() {
         }
         console.error("Error in handleAnalyseTeamClick:", error);
     } finally {
-        loadingIndicator.style.display = 'none';
-        loadingIndicator.textContent = 'Loading...'; // Reset text
-        fetchTeamButton.disabled = false;
+        if (loadingIndicator) {
+            loadingIndicator.style.display = 'none';
+            loadingIndicator.textContent = 'Loading...'; // Reset text
+        }
+        if (fetchTeamButton) {
+            fetchTeamButton.disabled = false;
+        }
     }
 }
 
@@ -208,9 +224,9 @@ async function fetchUserTeam(teamID, gameweekID) {
             }
             
             // Display error in relevant area (user or rival) based on which loading indicator is visible
-            if (loadingIndicator.style.display === 'inline') { 
+            if (loadingIndicator && loadingIndicator.style.display === 'inline' && userTeamSquad) {
                  userTeamSquad.innerHTML = `<p class="error-message">${message}</p>`;
-            } else if (rivalLoadingIndicator.style.display === 'inline') { 
+            } else if (rivalLoadingIndicator && rivalLoadingIndicator.style.display === 'inline' && comparisonResults) {
                  comparisonResults.innerHTML = `<p class="error-message">${message}</p>`;
             }
             
@@ -222,9 +238,9 @@ async function fetchUserTeam(teamID, gameweekID) {
     } catch (error) {
         console.error(`Error fetching user team data for ID ${teamID}:`, error);
         // Generic message if not set by HTTP error, specific to context
-        if (loadingIndicator.style.display === 'inline' && userTeamSquad.innerHTML === '') {
+        if (loadingIndicator && loadingIndicator.style.display === 'inline' && userTeamSquad && userTeamSquad.innerHTML === '') {
             userTeamSquad.innerHTML = `<p class="error-message">Failed to fetch team data for Team ID ${teamID}: ${error.message}. Check ID and network.</p>`;
-        } else if (rivalLoadingIndicator.style.display === 'inline' && comparisonResults.innerHTML === '') {
+        } else if (rivalLoadingIndicator && rivalLoadingIndicator.style.display === 'inline' && comparisonResults && comparisonResults.innerHTML === '') {
             comparisonResults.innerHTML = `<p class="error-message">Failed to fetch data for one of the teams (ID: ${teamID}): ${error.message}. Check ID and network.</p>`;
         }
         return null;
@@ -236,6 +252,10 @@ async function fetchUserTeam(teamID, gameweekID) {
  * @param {Array} teamPicks Array of player picks from fetchUserTeam.
  */
 function displayUserTeam(teamPicks) {
+    if (!userTeamSquad || !userTeamEpNext) {
+        console.error("Missing DOM elements for displayUserTeam.");
+        return;
+    }
     userTeamSquad.innerHTML = ''; 
     let totalEpNext = 0;
 
@@ -282,6 +302,10 @@ function displayUserTeam(teamPicks) {
  * @param {Array} currentPicks Array of player picks from the user's current team.
  */
 function displayBasicOptimisation(currentPicks) {
+    if (!suggestionsContent) {
+        console.error("Missing DOM element for displayBasicOptimisation.");
+        return;
+    }
     suggestionsContent.innerHTML = ''; 
 
     if (!allPlayersData.length) {
@@ -323,6 +347,11 @@ function displayBasicOptimisation(currentPicks) {
  * Handles the click event for the "Compare" button.
  */
 async function handleCompareTeamClick() {
+    if (!teamIdInput || !rivalTeamIdInput || !compareTeamButton || !rivalLoadingIndicator || !comparisonResults) {
+        console.error("One or more comparison DOM elements are missing for handleCompareTeamClick.");
+        return;
+    }
+
     const userTeamID = teamIdInput.value.trim();
     const rivalTeamID = rivalTeamIdInput.value.trim();
 
@@ -351,7 +380,7 @@ async function handleCompareTeamClick() {
         ]);
 
         if (userTeamData && userTeamData.picks && rivalTeamData && rivalTeamData.picks) {
-            generateComparisonSuggestions(userTeamData.picks, rivalTeamData.picks);
+            generateComparisonSuggestions(userTeamData.picks, rivalTeamData.picks); // This function also needs to be robust
         } else {
             if (comparisonResults.innerHTML === '') { 
                  comparisonResults.innerHTML = `<p class="error-message">Could not retrieve data for one or both teams. Please check IDs and try again.</p>`;
@@ -363,9 +392,13 @@ async function handleCompareTeamClick() {
             comparisonResults.innerHTML = `<p class="error-message">An error occurred while comparing teams: ${error.message}.</p>`;
         }
     } finally {
-        rivalLoadingIndicator.style.display = 'none';
-        rivalLoadingIndicator.textContent = 'Loading rival...'; 
-        compareTeamButton.disabled = false;
+        if(rivalLoadingIndicator) {
+            rivalLoadingIndicator.style.display = 'none';
+            rivalLoadingIndicator.textContent = 'Loading rival...'; 
+        }
+        if(compareTeamButton) {
+            compareTeamButton.disabled = false;
+        }
     }
 }
 
@@ -375,6 +408,10 @@ async function handleCompareTeamClick() {
  * @param {Array} rivalPicks Array of rival's player picks.
  */
 function generateComparisonSuggestions(userPicks, rivalPicks) {
+    if (!comparisonResults) {
+        console.error("Missing DOM element for generateComparisonSuggestions.");
+        return;
+    }
     comparisonResults.innerHTML = ''; 
 
     const userPlayerIds = new Set(userPicks.map(p => p.element));
@@ -633,7 +670,9 @@ function updateSquadDisplay() {
 
     // Refresh player table to update "Add" button states
     // This is important if a player is removed, their "Add" button should be re-enabled.
-    populatePlayerTable();
+    if (playerListTbody && positionFilter) { // Only call if planner elements are likely there
+        populatePlayerTable();
+    }
 }
 
 /**


### PR DESCRIPTION
- I updated the main navigation in index.html to link to new analyser.html and planner.html pages.
- I created analyser.html and moved the 'analysis' section content from index.html to it.
- I created planner.html and moved the 'team-planner-section' content from index.html to it.
- I ensured both new pages include necessary CSS and JavaScript.
- I verified JavaScript continues to function correctly on the new pages.
- I performed basic testing which confirmed navigation and content display.