### PR TITLE
Fix: Update top navigation links and ensure visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
         .logo span {
             color: var(--secondary);
         }
+
+        nav {
+            position: relative; /* Ensure nav is part of the layout flow by default */
+            left: auto; /* Default 'left' for desktop */
+        }
         
         nav ul {
             display: flex;
@@ -915,8 +920,8 @@
                 </ul>
             </nav>
             <div class="auth-buttons">
-                <a href="#" class="btn btn-outline">Log In</a>
-                <a href="#" class="btn btn-primary">Sign Up Free</a>
+                <a href="analyser.html" class="btn btn-outline">Analyser</a>
+                <a href="planner.html" class="btn btn-primary">25/26 Planner</a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
- I replaced 'Log In' and 'Sign Up Free' buttons with direct links to 'Analyser' and '25/26 Planner' pages in the header.
- I adjusted header CSS to ensure the main navigation menu (Features, Predictions, etc.) is visible on desktop views.
- I verified that mobile navigation remains functional, hiding the menu off-screen by default and toggling with the mobile menu button.

The issue of main navigation links not being visible on desktop should now be resolved, and the requested 'Analyser' and '25/26 Planner' links are in place of the previous auth buttons.